### PR TITLE
feat(foreach): add async generator based forEach function per job type

### DIFF
--- a/iterUtils.js
+++ b/iterUtils.js
@@ -1,0 +1,76 @@
+const sift = require('sift').default;
+
+/**
+ * @template T
+ * @param {(function(T): boolean | Promise<boolean>) | Object} filter
+ * @param {AsyncIterable<T> | AsyncIterator<T>} iter
+ * @returns {AsyncIterator<T>}
+ */
+async function *filterIt(filter, iter) {
+  const filterFn = typeof filter === 'function' ? filter : sift(filter);
+  for await (const item of iter) {
+    if (await filterFn(item)) {
+      yield item;
+    }
+  }
+}
+
+/**
+ * @template T
+ * @implements AsyncIterable<T>
+ */
+class DecoratedIterable {
+  /**
+   * @param {AsyncIterable<T> | AsyncIterator<T>} iter
+   */
+  constructor(iter) {
+    this.iter = iter;
+  }
+
+  async *[Symbol.asyncIterator]() {
+    for await (const item of this.iter) {
+      yield item;
+    }
+  }
+
+  /**
+   * @param {function(T)} fn
+   * @returns {Promise<void>}
+   */
+  async forEach(fn) {
+    for await (const item of this.iter) {
+      await fn(item);
+    }
+  }
+
+  /**
+   * @param {(function(T): boolean | Promise<boolean>) | Object} filter
+   * @returns {DecoratedIterable<T>}
+   */
+  filter(filter) {
+    return new DecoratedIterable(filterIt(filter, this));
+  }
+
+  /**
+   * @returns {Promise<T[]>}
+   */
+  async toArray() {
+    const result = [];
+    for await (const item of this.iter) {
+      result.push(item);
+    }
+    return result;
+  }
+}
+
+module.exports = {
+
+  /**
+   * @template T
+   * @param {AsyncIterable<T> | AsyncIterator<T>} iter
+   * @returns {DecoratedIterable<T>}
+   */
+  decorateIt(iter) {
+    return new DecoratedIterable(iter);
+  }
+};

--- a/repl.js
+++ b/repl.js
@@ -9,6 +9,10 @@ const sift = require('sift').default;
 const getValue = require('get-value');
 
 /**
+ * @typedef {'waiting' | 'active' | 'succeeded' | 'failed' | 'delayed'} JobType
+ */
+
+/**
  * Creates a (honey)combee to allow introspection of bee-queue jobs.
  */
 class Combee {
@@ -131,8 +135,8 @@ class CombeeQueue {
    * Returns all the jobs for the given job type in the given page, and prints them
    * in a console-friendly way.
    *
-   * @param {string} jobType The type of job (i.e. 'active', 'waiting', etc).
-   * @param {Object} page The page info.
+   * @param {JobType} jobType The type of job (i.e. 'active', 'waiting', etc).
+   * @param {Object}  page    The page info.
    *   @property {number} start The start of the page.
    *   @property {number} end The end of the page.
    *   @property {number} size The size of the page.
@@ -170,7 +174,7 @@ class CombeeQueue {
   /**
    * Removes jobs of the given type that match the given filter.
    *
-   * @param {string}            jobType The type of job to remove matches from.
+   * @param {JobType}           jobType The type of job to remove matches from.
    * @param {function | Object} filter  A function, or a sift-compatible filter
    */
   removeJobs(jobType, filter) {
@@ -181,31 +185,19 @@ class CombeeQueue {
    * Utility function for removing jobs that match the given criteria
    * (the job type and filter).
    *
-   * @param {string}            jobType The type of job to remove matches from.
+   * @param {JobType}           jobType The type of job to remove matches from.
    * @param {function | Object} filter  A function, or a sift-compatible filter
    */
   async removeJobsAsync(jobType, filter) {
-    const BATCH_SIZE = 50;
-    const jobStats = await this.queue.checkHealth();
-    const count = jobStats[jobType];
     const filterFn = typeof filter === 'function' ? filter : sift(filter);
 
     let numRemoved = 0;
 
-    for (let i = 0; i < count; i += BATCH_SIZE) {
-      const jobs = await this.queue.getJobs(jobType, {
-        size: BATCH_SIZE,
-        start: i,
-        end: i + BATCH_SIZE - 1,
-      });
-
-      const matched = jobs.filter(filterFn);
-      if (!matched || !matched.length) {
-        continue;
+    for await (const job of this.iterate(jobType)) {
+      if (filterFn(job)) {
+        await job.remove();
+        numRemoved++;
       }
-
-      await Promise.all(matched.map((job) => job.remove()));
-      numRemoved += matched.length;
     }
 
     console.log(`removed ${numRemoved} jobs`);
@@ -217,7 +209,7 @@ class CombeeQueue {
    * Utility function for finding jobs that match the given criteria
    * (the job type and filter).
    *
-   * @param {string}            jobType The type of job to search.
+   * @param {JobType}           jobType The type of job to search.
    * @param {function | Object} filter  A function, or a sift-compatible filter
    */
   async find(jobType, filter = {}) {
@@ -234,7 +226,7 @@ class CombeeQueue {
   /**
    * Counts the number of jobs matching the given type and filter.
    *
-   * @param {string}            jobType The type of job to search.
+   * @param {JobType}           jobType The type of job to search.
    * @param {function | Object} filter  A function, or a sift-compatible filter
    * @return {Promise<number>}
    */
@@ -253,19 +245,20 @@ class CombeeQueue {
    * Prints the distinct values of `field` and their counts across all jobs matching
    * the given type and filter. Returns an array of all distinct values.
    *
-   * @param {string}            jobType The type of job to search.
+   * @param {JobType}           jobType The type of job to search.
    * @param {string}            field   The job field to find the distinct values of
    * @param {function | Object} filter  A function, or a sift-compatible filter
    * @return {Promise<*[]>}  An array containing the distinct values of `field` in the matching jobs
    */
   async distinctAsync(jobType, field, filter) {
-    const matches = await this._find(jobType, filter);
-
+    const filterFn = typeof filter === 'function' ? filter : sift(filter);
     const vals = new Map();
 
-    for (const match of matches) {
-      const val = getValue(match, field);
-      vals.set(val, (vals.get(val) || 0) + 1);
+    for await (const job of this.iterate(jobType)) {
+      if (filterFn(job)) {
+        const val = getValue(job, field);
+        vals.set(val, (vals.get(val) || 0) + 1);
+      }
     }
 
     console.log(); // purge to next line for readability
@@ -279,12 +272,26 @@ class CombeeQueue {
   }
 
   async _find(jobType, filter) {
+    const filterFn = typeof filter === 'function' ? filter : sift(filter);
+    const matches = [];
+
+    for await (const job of this.iterate(jobType)) {
+      if (filterFn(job)) {
+        matches.push(job);
+      }
+    }
+
+    return matches;
+  }
+
+  /**
+   * @param {JobType} jobType
+   * @returns {AsyncGenerator<BeeQueue.Job>}
+   */
+  async* iterate(jobType) {
     const BATCH_SIZE = 50;
     const jobStats = await this.queue.checkHealth();
     const count = jobStats[jobType];
-    const filterFn = typeof filter === 'function' ? filter : sift(filter);
-
-    let matches = [];
 
     for (let i = 0; i < count; i += BATCH_SIZE) {
       const jobs = await this.queue.getJobs(jobType, {
@@ -293,13 +300,21 @@ class CombeeQueue {
         end: i + BATCH_SIZE - 1,
       });
 
-      const matched = jobs.filter(filterFn);
-      if (matched && matched.length) {
-        matches = matches.concat(matched);
+      for (const job of jobs) {
+        yield job;
       }
     }
+  }
 
-    return matches;
+  /**
+   * @param {JobType} jobType
+   * @param {function(BeeQueue.Job)} fn The function to execute on each job of the given type
+   * @returns {Promise<void>}
+   */
+  async forEach(jobType, fn) {
+    for await (const job of this.iterate(jobType)) {
+      await fn(job);
+    }
   }
 }
 


### PR DESCRIPTION
Adds an async generator over jobs by type (`iterate`), and implements `forEach`, `distinct`, `remove`, and `find` in terms of it (refactoring the latter 3).

Should help with https://github.com/ttacon/combee/pull/11.